### PR TITLE
Improve docs for image classification project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,35 @@
 # AI-Programming-with-Python-Nanodegree
-This Repo Contains my Submission For Udacity AI nanodegree Course
+
+This project classifies pet images using pretrained convolutional neural network (CNN) models. The code compares the predicted labels with the actual breed names encoded in the image filenames and reports statistics for each run.
+
+## Prerequisites
+
+- Python 3.6 or higher
+- [PyTorch](https://pytorch.org) and torchvision
+- Pillow
+
+Install the dependencies with:
+
+```bash
+pip install torch torchvision pillow
+```
+
+## Running `check_images.py`
+
+1. Place the images you want to classify in a directory (the default `pet_images/` directory is already included).
+2. Execute `check_images.py`, choosing one of the supported model architectures (`resnet`, `alexnet`, or `vgg`):
+
+```bash
+python check_images.py --dir pet_images/ --arch vgg --dogfile dognames.txt
+```
+
+The script will print the classification results along with summary statistics.
+
+## Batch scripts
+
+Two optional shell scripts run all three models and save the output:
+
+- `run_models_batch.sh` processes the `pet_images/` directory.
+- `run_models_batch_uploaded.sh` processes the `uploaded_images/` directory.
+
+Running either script generates text files (for example `resnet_pet-images.txt` or `vgg_uploaded-images.txt`) containing the program output so you can review the results later.


### PR DESCRIPTION
## Summary
- expand README with overview
- list prerequisites and installation
- add steps for running `check_images.py`
- document optional batch scripts

## Testing
- `python check_images.py --dir pet_images/ --arch vgg --dogfile dognames.txt` *(fails: ModuleNotFoundError: No module named 'PIL')*
- `pip install pillow` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684619f218ec8320a1cffededac9bccf