### PR TITLE
Clean TODOs and standardize style

### DIFF
--- a/adjust_results4_isadog.py
+++ b/adjust_results4_isadog.py
@@ -1,68 +1,65 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # */AIPND-revision/intropyproject-classify-pet-images/adjust_results4_isadog.py
-#                                                                             
+#
 # PROGRAMMER: Nick Ferguson
-# DATE CREATED: 2/7/23                         
+# DATE CREATED: 2/7/23
 # REVISED DATE: 2/26/23
-# PURPOSE: Create a function adjust_results4_isadog that adjusts the results 
-#          dictionary to indicate whether or not the pet image label is of-a-dog, 
+# PURPOSE: Create a function adjust_results4_isadog that adjusts the results
+#          dictionary to indicate whether or not the pet image label is of-a-dog,
 #          and to indicate whether or not the classifier image label is of-a-dog.
 #          All dog labels from both the pet images and the classifier function
 #          will be found in the dognames.txt file. We recommend reading all the
-#          dog names in dognames.txt into a dictionary where the 'key' is the 
-#          dog name (from dognames.txt) and the 'value' is one. If a label is 
-#          found to exist within this dictionary of dog names then the label 
-#          is of-a-dog, otherwise the label isn't of a dog. Alternatively one 
+#          dog names in dognames.txt into a dictionary where the 'key' is the
+#          dog name (from dognames.txt) and the 'value' is one. If a label is
+#          found to exist within this dictionary of dog names then the label
+#          is of-a-dog, otherwise the label isn't of a dog. Alternatively one
 #          could also read all the dog names into a list and then if the label
 #          is found to exist within this list - the label is of-a-dog, otherwise
-#          the label isn't of a dog. 
+#          the label isn't of a dog.
 #         This function inputs:
-#            -The results dictionary as results_dic within adjust_results4_isadog 
+#            -The results dictionary as results_dic within adjust_results4_isadog
 #             function and results for the function call within main.
 #            -The text file with dog names as dogfile within adjust_results4_isadog
-#             function and in_arg.dogfile for the function call within main. 
-#           This function uses the extend function to add items to the list 
+#             function and in_arg.dogfile for the function call within main.
+#           This function uses the extend function to add items to the list
 #           that's the 'value' of the results dictionary. You will be adding the
 #           whether or not the pet image label is of-a-dog as the item at index
 #           3 of the list and whether or not the classifier label is of-a-dog as
 #           the item at index 4 of the list. Note we recommend setting the values
-#           at indices 3 & 4 to 1 when the label is of-a-dog and to 0 when the 
+#           at indices 3 & 4 to 1 when the label is of-a-dog and to 0 when the
 #           label isn't a dog.
 #
-##
-# TODO 4: Define adjust_results4_isadog function below, specifically replace the None
-#       below by the function definition of the adjust_results4_isadog function. 
-#       Notice that this function doesn't return anything because the 
-#       results_dic dictionary that is passed into the function is a mutable 
+#       Notice that this function doesn't return anything because the
+#       results_dic dictionary that is passed into the function is a mutable
 #       data type so no return is needed.
-# 
+#
 def adjust_results4_isadog(results_dic, dogfile):
     """
-    Adjusts the results dictionary to determine if classifier correctly 
-    classified images 'as a dog' or 'not a dog' especially when not a match. 
+    Adjusts the results dictionary to determine if classifier correctly
+    classified images 'as a dog' or 'not a dog' especially when not a match.
     Demonstrates if model architecture correctly classifies dog images even if
     it gets dog breed wrong (not a match).
     Parameters:
-      results_dic - Dictionary with 'key' as image filename and 'value' as a 
-                    List. Where the list will contain the following items: 
+      results_dic - Dictionary with 'key' as image filename and 'value' as a
+                    List. Where the list will contain the following items:
                   index 0 = pet image label (string)
                   index 1 = classifier label (string)
                   index 2 = 1/0 (int)  where 1 = match between pet image
                     and classifer labels and 0 = no match between labels
                 ------ where index 3 & index 4 are added by this function -----
-                 NEW - index 3 = 1/0 (int)  where 1 = pet image 'is-a' dog and 
-                            0 = pet Image 'is-NOT-a' dog. 
-                 NEW - index 4 = 1/0 (int)  where 1 = Classifier classifies image 
-                            'as-a' dog and 0 = Classifier classifies image  
+                 NEW - index 3 = 1/0 (int)  where 1 = pet image 'is-a' dog and
+                            0 = pet Image 'is-NOT-a' dog.
+                 NEW - index 4 = 1/0 (int)  where 1 = Classifier classifies image
+                            'as-a' dog and 0 = Classifier classifies image
                             'as-NOT-a' dog.
      dogfile - A text file that contains names of all dogs from the classifier
-               function and dog names from the pet image files. This file has 
-               one dog name per line dog names are all in lowercase with 
+               function and dog names from the pet image files. This file has
+               one dog name per line dog names are all in lowercase with
                spaces separating the distinct words of the dog name. Dog names
                from the classifier function can be a string of dog names separated
-               by commas when a particular breed of dog has multiple dog names 
-               associated with that breed (ex. maltese dog, maltese terrier, 
+               by commas when a particular breed of dog has multiple dog names
+               associated with that breed (ex. maltese dog, maltese terrier,
                maltese) (string - indicates text file's filename)
     Returns:
            None - results_dic is mutable data type so no return needed.
@@ -70,29 +67,29 @@ def adjust_results4_isadog(results_dic, dogfile):
     # Creates dognames dictionary for quick matching to results_dic labels from
     # real answer & classifier's answer
     dognames_dic = dict()
-    
+
     # Reads in dognames from file, 1 name per line and automatically closes file
     with open(dogfile, "r") as infile:
         # Reads in dognames from first line in file
         line = infile.readline()
-        
+
         # Processes each line in file until reaching EOF (end-of-file) by
         # processing line and adding dognames to dognames_dic with while loop
         while line != "":
-            
+
             # Process line by striping newline from line
             line = line.rstrip()
-            
+
             # Adds dognames_dic if it doesn't already exist in dic
             if line not in dognames_dic:
                 dognames_dic[line] = 1
             else:
                 print("**Warning: Duplicate dognames", line)
-                
+
             # Reads in next line in file to be processed with while loop
             # if this line isn't empty (EOF)
             line = infile.readline()
-    
+
     # Add to whether pet labels & classifier labels are dogs by appending
     # two lines to end of value(list) in results_dic.
     # List Index 3 = whether(1) or not(0) Pet Image Label is a dog AND
@@ -100,30 +97,28 @@ def adjust_results4_isadog(results_dic, dogfile):
     # How - iterate through results_dic if labels are found in dognames_dic
     # then label "is a dog" index3/4=1 otherwise index3/4=0 "not a dog"
     for key, value in results_dic.items():
-        
+
         # Pet Image Label IS of Dog (e.g. found in dognames_dic)
         if value[0] in dognames_dic:
-            
+
             # Classifier Label IS image of Dog (e.g. found in dognames_dic)
             # appends (1,1) because both labels are dogs
             if value[1] in dognames_dic:
                 value.extend((1, 1))
-                
+
             # Classifier Label IS NOT image of dog (e.g. NOT in dognames_dic)
             # appends (1, 0) because only pet label is a dog
             else:
                 value.extend((1, 0))
-                
+
         # Pet Image Label IS NOT a Dog image (e.g. NOT found in dognames_dic)
-        else:  
+        else:
             # Classifier Label IS image of Dog (e.g. found in dognames_dic)
             # appends(0, 1) becasue only Classifier label is a dog
             if value[1] in dognames_dic:
                 value.extend((0, 1))
-                
+
             # Classifier Label IS NOT image of Dog (e.g. NOT in dognames_dic)
             # appends (0, 0) because both labels aren't dogs
             else:
                 value.extend((0, 0))
-                            
-                            

--- a/calculates_results_stats.py
+++ b/calculates_results_stats.py
@@ -1,29 +1,29 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # */AIPND-revision/intropyproject-classify-pet-images/calculates_results_stats.py
-#                                                                             
+#
 # PROGRAMMER: Nick Ferguson
-# DATE CREATED: 2/7/23                                 
+# DATE CREATED: 2/7/23
 # REVISED DATE: 2/26/23
-# PURPOSE: Create a function calculates_results_stats that calculates the 
-#          statistics of the results of the programrun using the classifier's model 
-#          architecture to classify the images. This function will use the 
-#          results in the results dictionary to calculate these statistics. 
+# PURPOSE: Create a function calculates_results_stats that calculates the
+#          statistics of the results of the programrun using the classifier's model
+#          architecture to classify the images. This function will use the
+#          results in the results dictionary to calculate these statistics.
 #          This function will then put the results statistics in a dictionary
 #          (results_stats_dic) that's created and returned by this function.
-#          This will allow the user of the program to determine the 'best' 
+#          This will allow the user of the program to determine the 'best'
 #          model for classifying the images. The statistics that are calculated
 #          will be counts and percentages. Please see "Intro to Python - Project
-#          classifying Images - xx Calculating Results" for details on the 
-#          how to calculate the counts and percentages for this function.    
+#          classifying Images - xx Calculating Results" for details on the
+#          how to calculate the counts and percentages for this function.
 #         This function inputs:
-#            -The results dictionary as results_dic within calculates_results_stats 
+#            -The results dictionary as results_dic within calculates_results_stats
 #             function and results for the function call within main.
 #         This function creates and returns the Results Statistics Dictionary -
-#          results_stats_dic. This dictionary contains the results statistics 
-#          (either a percentage or a count) where the key is the statistic's 
-#           name (starting with 'pct' for percentage or 'n' for count) and value 
-#          is the statistic's value.  This dictionary should contain the 
+#          results_stats_dic. This dictionary contains the results statistics
+#          (either a percentage or a count) where the key is the statistic's
+#           name (starting with 'pct' for percentage or 'n' for count) and value
+#          is the statistic's value.  This dictionary should contain the
 #          following keys:
 #            n_images - number of images
 #            n_dogs_img - number of dog images
@@ -38,112 +38,108 @@
 #            pct_correct_notdogs - percentage of correctly classified NON-dogs
 #
 ##
-# TODO 5: Define calculates_results_stats function below, please be certain to replace None
-#       in the return statement with the results_stats_dic dictionary that you create 
+#       in the return statement with the results_stats_dic dictionary that you create
 #       with this function
-# 
+#
 def calculates_results_stats(results_dic):
     """
-    Calculates statistics of the results of the program run using classifier's model 
-    architecture to classifying pet images. Then puts the results statistics in a 
+    Calculates statistics of the results of the program run using classifier's model
+    architecture to classifying pet images. Then puts the results statistics in a
     dictionary (results_stats_dic) so that it's returned for printing as to help
-    the user to determine the 'best' model for classifying images. Note that 
+    the user to determine the 'best' model for classifying images. Note that
     the statistics calculated as the results are either percentages or counts.
     Parameters:
-      results_dic - Dictionary with key as image filename and value as a List 
+      results_dic - Dictionary with key as image filename and value as a List
              (index)idx 0 = pet image label (string)
                     idx 1 = classifier label (string)
-                    idx 2 = 1/0 (int)  where 1 = match between pet image and 
+                    idx 2 = 1/0 (int)  where 1 = match between pet image and
                             classifer labels and 0 = no match between labels
-                    idx 3 = 1/0 (int)  where 1 = pet image 'is-a' dog and 
-                            0 = pet Image 'is-NOT-a' dog. 
-                    idx 4 = 1/0 (int)  where 1 = Classifier classifies image 
-                            'as-a' dog and 0 = Classifier classifies image  
+                    idx 3 = 1/0 (int)  where 1 = pet image 'is-a' dog and
+                            0 = pet Image 'is-NOT-a' dog.
+                    idx 4 = 1/0 (int)  where 1 = Classifier classifies image
+                            'as-a' dog and 0 = Classifier classifies image
                             'as-NOT-a' dog.
     Returns:
      results_stats_dic - Dictionary that contains the results statistics (either
-                    a percentage or a count) where the key is the statistic's 
+                    a percentage or a count) where the key is the statistic's
                      name (starting with 'pct' for percentage or 'n' for count)
                      and the value is the statistic's value. See comments above
                      and the previous topic Calculating Results in the class for details
                      on how to calculate the counts and statistics.
-    """        
+    """
     # Creates empty dictionary for results_stats_dic
     results_stats_dic = dict()
-    
-    # Sets all counters to initial values of zero so that they can 
-    # be incremented while processing through the images in results_dic 
-    results_stats_dic['n_dogs_img'] = 0
-    results_stats_dic['n_match'] = 0
-    results_stats_dic['n_correct_dogs'] = 0
-    results_stats_dic['n_correct_notdogs'] = 0
-    results_stats_dic['n_correct_breed'] = 0       
-    
+
+    # Sets all counters to initial values of zero so that they can
+    # be incremented while processing through the images in results_dic
+    results_stats_dic["n_dogs_img"] = 0
+    results_stats_dic["n_match"] = 0
+    results_stats_dic["n_correct_dogs"] = 0
+    results_stats_dic["n_correct_notdogs"] = 0
+    results_stats_dic["n_correct_breed"] = 0
+
     # process through the results dictionary
     for key in results_dic:
-         
+
         # Labels Match Exactly
         if results_dic[key][2] == 1:
-            results_stats_dic['n_match'] += 1
-            
+            results_stats_dic["n_match"] += 1
+
         # Pet Image Label is a Dog AND Labels match- counts Correct Breed
         if results_dic[key][2] and results_dic[key][3]:
-            results_stats_dic['n_correct_breed'] += 1
-        
+            results_stats_dic["n_correct_breed"] += 1
+
         # Pet Image Label is a Dog - counts number of dog images
         if results_dic[key][3] == 1:
-            results_stats_dic['n_dogs_img'] += 1
-            
+            results_stats_dic["n_dogs_img"] += 1
+
             # Classifier classifies image as Dog (& pet image is a dog)
             # counts number of correct dog classifications
             if results_dic[key][4] == 1:
-                results_stats_dic['n_correct_dogs'] += 1
-                
+                results_stats_dic["n_correct_dogs"] += 1
+
         # Pet Image Label is NOT a Dog
         else:
             # Classifier classifies image as NOT a Dog(& pet image isn't a dog)
             # counts number of correct NOT dog clasifications.
-             if results_dic[key][4] == 0:
-                    results_stats_dic['n_correct_notdogs'] += 1
+            if results_dic[key][4] == 0:
+                results_stats_dic["n_correct_notdogs"] += 1
 
-            
     # Calculates run statistics (counts & percentages) below that are calculated
     # using the counters from above.
-    
+
     # calculates number of total images
-    results_stats_dic['n_images'] = len(results_dic)
+    results_stats_dic["n_images"] = len(results_dic)
 
     # calculates number of not-a-dog images using - images & dog images counts
-    results_stats_dic['n_notdogs_img'] = (results_stats_dic['n_images'] - 
-                                      results_stats_dic['n_dogs_img']) 
+    results_stats_dic["n_notdogs_img"] = (
+        results_stats_dic["n_images"] - results_stats_dic["n_dogs_img"]
+    )
 
     # Calculates % correct for matches
-    results_stats_dic['pct_match'] = results_stats_dic['n_match'] / results_stats_dic['n_images'] * 100.0
-    
+    results_stats_dic["pct_match"] = (
+        results_stats_dic["n_match"] / results_stats_dic["n_images"] * 100.0
+    )
+
     # Calculates % correct dogs
-    results_stats_dic['pct_correct_dogs'] = results_stats_dic['n_correct_dogs'] / results_stats_dic['n_dogs_img'] * 100.0
-    
+    results_stats_dic["pct_correct_dogs"] = (
+        results_stats_dic["n_correct_dogs"] / results_stats_dic["n_dogs_img"] * 100.0
+    )
+
     # Calculates % correct breed of dog
-    results_stats_dic['pct_correct_breed'] = results_stats_dic['n_correct_breed'] / results_stats_dic['n_dogs_img'] * 100.0
-    
+    results_stats_dic["pct_correct_breed"] = (
+        results_stats_dic["n_correct_breed"] / results_stats_dic["n_dogs_img"] * 100.0
+    )
+
     # Calculates % correct not-a-dog images
-    # Uses conditional statement for when no 'not a dog' images were submitted 
-    if results_stats_dic['n_notdogs_img'] > 0:
-        results_stats_dic['pct_correct_notdogs'] = (results_stats_dic['n_correct_notdogs'] /
-                                                results_stats_dic['n_notdogs_img'])*100.0
+    # Uses conditional statement for when no 'not a dog' images were submitted
+    if results_stats_dic["n_notdogs_img"] > 0:
+        results_stats_dic["pct_correct_notdogs"] = (
+            results_stats_dic["n_correct_notdogs"] / results_stats_dic["n_notdogs_img"]
+        ) * 100.0
     else:
-        results_stats_dic['pct_correct_notdogs'] = 0.0
-        
-    # Replace None with the results_stats_dic dictionary that you created with 
-    # this function 
+        results_stats_dic["pct_correct_notdogs"] = 0.0
+
+    # Replace None with the results_stats_dic dictionary that you created with
+    # this function
     return results_stats_dic
-                                          
-                                          
-                                          
-                                          
-                                          
-                                          
-                                      
-    
-    
-    

--- a/check_images.py
+++ b/check_images.py
@@ -2,17 +2,16 @@
 # -*- coding: utf-8 -*-
 # */AIPND-revision/intropyproject-classify-pet-images/check_images.py
 #
-# TODO 0: Add your information below for Programmer & Date Created.                                                                             
 # PROGRAMMER: Nick Ferguson
-# DATE CREATED: 2/6/23                      
+# DATE CREATED: 2/6/23
 # REVISED DATE: 2/11/23
 # PURPOSE: Classifies pet images using a pretrained CNN model, compares these
 #          classifications to the true identity of the pets in the images, and
-#          summarizes how well the CNN performed on the image classification task. 
-#          Note that the true identity of the pet (or object) in the image is 
+#          summarizes how well the CNN performed on the image classification task.
+#          Note that the true identity of the pet (or object) in the image is
 #          indicated by the filename of the image. Therefore, your program must
 #          first extract the pet image label from the filename before
-#          classifying the images using the pretrained CNN model. With this 
+#          classifying the images using the pretrained CNN model. With this
 #          program we will be comparing the performance of 3 different CNN model
 #          architectures to determine which provides the 'best' classification.
 #
@@ -37,38 +36,35 @@ from adjust_results4_isadog import adjust_results4_isadog
 from calculates_results_stats import calculates_results_stats
 from print_results import print_results
 
+
 # Main program function defined below
 def main():
     # Measures total program runtime by collecting start time
     start_time = time()
-    
-    # 
+
+    #
     in_arg = get_input_args()
 
-    # Function that checks command line arguments using in_arg  
+    # Function that checks command line arguments using in_arg
     check_command_line_arguments(in_arg)
 
-    
     # Insert new comment here
     results = get_pet_labels(in_arg.dir)
 
-    # Function that checks Pet Images in the results Dictionary using results    
+    # Function that checks Pet Images in the results Dictionary using results
     check_creating_pet_image_labels(results)
-
 
     # insert new comment here
     classify_images(in_arg.dir, results, in_arg.arch)
 
-    # Function that checks Results Dictionary using results    
-    check_classifying_images(results)    
+    # Function that checks Results Dictionary using results
+    check_classifying_images(results)
 
-    
     # insert new comment here
     adjust_results4_isadog(results, in_arg.dogfile)
 
     # Function that checks Results Dictionary for is-a-dog adjustment using results
     check_classifying_labels_as_dogs(results)
-
 
     # insert new comment here
     results_stats = calculates_results_stats(results)
@@ -76,19 +72,25 @@ def main():
     # Function that checks Results Statistics Dictionary using results_stats
     check_calculating_results(results, results_stats)
 
-
     # Function to print out results of model prediction performance
     print_results(results, results_stats, in_arg.arch, True, True)
-    
+
     # Measure total program runtime by collecting end time
     end_time = time()
-    
+
     # Computes overall runtime in seconds & prints it in hh:mm:ss format
-    tot_time = end_time - start_time #calculate difference between end time and start time
-    print("\n** Total Elapsed Runtime:",
-          str(int((tot_time/3600)))+":"+str(int((tot_time%3600)/60))+":"
-          +str(int((tot_time%3600)%60)) )
-    
+    tot_time = (
+        end_time - start_time
+    )  # calculate difference between end time and start time
+    print(
+        "\n** Total Elapsed Runtime:",
+        str(int((tot_time / 3600)))
+        + ":"
+        + str(int((tot_time % 3600) / 60))
+        + ":"
+        + str(int((tot_time % 3600) % 60)),
+    )
+
 
 # Call to main function to run the program
 if __name__ == "__main__":

--- a/classifier.py
+++ b/classifier.py
@@ -1,3 +1,8 @@
+"""
+Utility functions for image classification using pretrained CNN models.
+Defines the classifier() function that returns a label for an image.
+"""
+
 import ast
 from PIL import Image
 import torchvision.transforms as transforms
@@ -9,47 +14,50 @@ resnet18 = models.resnet18(pretrained=True)
 alexnet = models.alexnet(pretrained=True)
 vgg16 = models.vgg16(pretrained=True)
 
-models = {'resnet': resnet18, 'alexnet': alexnet, 'vgg': vgg16}
+models = {"resnet": resnet18, "alexnet": alexnet, "vgg": vgg16}
 
 # obtain ImageNet labels
-with open('imagenet1000_clsid_to_human.txt') as imagenet_classes_file:
+with open("imagenet1000_clsid_to_human.txt") as imagenet_classes_file:
     imagenet_classes_dict = ast.literal_eval(imagenet_classes_file.read())
+
 
 def classifier(img_path, model_name):
     # load the image
     img_pil = Image.open(img_path)
 
     # define transforms
-    preprocess = transforms.Compose([
-        transforms.Resize(256),
-        transforms.CenterCrop(224),
-        transforms.ToTensor(),
-        transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225])
-    ])
-    
+    preprocess = transforms.Compose(
+        [
+            transforms.Resize(256),
+            transforms.CenterCrop(224),
+            transforms.ToTensor(),
+            transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
+        ]
+    )
+
     # preprocess the image
     img_tensor = preprocess(img_pil)
-    
+
     # resize the tensor (add dimension for batch)
     img_tensor.unsqueeze_(0)
-    
+
     # wrap input in variable, wrap input in variable - no longer needed for
     # v 0.4 & higher code changed 04/26/2018 by Jennifer S. to handle PyTorch upgrade
-    pytorch_ver = __version__.split('.')
-    
+    pytorch_ver = __version__.split(".")
+
     # pytorch versions 0.4 & hihger - Variable depreciated so that it returns
-    # a tensor. So to address tensor as output (not wrapper) and to mimic the 
+    # a tensor. So to address tensor as output (not wrapper) and to mimic the
     # affect of setting volatile = True (because we are using pretrained models
-    # for inference) we can set requires_gradient to False. Here we just set 
-    # requires_grad_ to False on our tensor 
+    # for inference) we can set requires_gradient to False. Here we just set
+    # requires_grad_ to False on our tensor
     if int(pytorch_ver[0]) > 0 or int(pytorch_ver[1]) >= 4:
         img_tensor.requires_grad_(False)
-    
+
     # pytorch versions less than 0.4 - uses Variable because not-depreciated
     else:
         # apply model to input
         # wrap input in variable
-        data = Variable(img_tensor, volatile = True) 
+        data = Variable(img_tensor, volatile=True)
 
     # apply model to input
     model = models[model_name]
@@ -57,8 +65,8 @@ def classifier(img_path, model_name):
     # puts model in evaluation mode
     # instead of (default)training mode
     model = model.eval()
-    
-    # apply data to model - adjusted based upon version to account for 
+
+    # apply data to model - adjusted based upon version to account for
     # operating on a Tensor for version 0.4 & higher.
     if int(pytorch_ver[0]) > 0 or int(pytorch_ver[1]) >= 4:
         output = model(img_tensor)

--- a/classify_images.py
+++ b/classify_images.py
@@ -1,94 +1,94 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # */AIPND-revision/intropyproject-classify-pet-images/classify_images.py
-#                                                                             
+#
 # PROGRAMMER: Nick Ferguson
-# DATE CREATED: 2/7/23                                
+# DATE CREATED: 2/7/23
 # REVISED DATE: 2/26/23
-# PURPOSE: Create a function classify_images that uses the classifier function 
-#          to create the classifier labels and then compares the classifier 
+# PURPOSE: Create a function classify_images that uses the classifier function
+#          to create the classifier labels and then compares the classifier
 #          labels to the pet image labels. This function inputs:
-#            -The Image Folder as image_dir within classify_images and function 
-#             and as in_arg.dir for function call within main. 
-#            -The results dictionary as results_dic within classify_images 
+#            -The Image Folder as image_dir within classify_images and function
+#             and as in_arg.dir for function call within main.
+#            -The results dictionary as results_dic within classify_images
 #             function and results for the functin call within main.
 #            -The CNN model architecture as model wihtin classify_images function
-#             and in_arg.arch for the function call within main. 
-#           This function uses the extend function to add items to the list 
+#             and in_arg.arch for the function call within main.
+#           This function uses the extend function to add items to the list
 #           that's the 'value' of the results dictionary. You will be adding the
-#           classifier label as the item at index 1 of the list and the comparison 
+#           classifier label as the item at index 1 of the list and the comparison
 #           of the pet and classifier labels as the item at index 2 of the list.
 #
 ##
-# Imports classifier function for using CNN to classify images 
+# Imports classifier function for using CNN to classify images
 from classifier import classifier
 import os
 
-# TODO 3: Define classify_images function below, specifically replace the None
-#       below by the function definition of the classify_images function. 
-#       Notice that this function doesn't return anything because the 
-#       results_dic dictionary that is passed into the function is a mutable 
+
+#       below by the function definition of the classify_images function.
+#       Notice that this function doesn't return anything because the
+#       results_dic dictionary that is passed into the function is a mutable
 #       data type so no return is needed.
-# 
+#
 def classify_images(images_dir, results_dic, model):
     """
-    Creates classifier labels with classifier function, compares pet labels to 
-    the classifier labels, and adds the classifier label and the comparison of 
+    Creates classifier labels with classifier function, compares pet labels to
+    the classifier labels, and adds the classifier label and the comparison of
     the labels to the results dictionary using the extend function. Be sure to
     format the classifier labels so that they will match your pet image labels.
-    The format will include putting the classifier labels in all lower case 
+    The format will include putting the classifier labels in all lower case
     letters and strip the leading and trailing whitespace characters from them.
-    For example, the Classifier function returns = 'Maltese dog, Maltese terrier, Maltese' 
+    For example, the Classifier function returns = 'Maltese dog, Maltese terrier, Maltese'
     so the classifier label = 'maltese dog, maltese terrier, maltese'.
-    Recall that dog names from the classifier function can be a string of dog 
-    names separated by commas when a particular breed of dog has multiple dog 
+    Recall that dog names from the classifier function can be a string of dog
+    names separated by commas when a particular breed of dog has multiple dog
     names associated with that breed. For example, you will find pet images of
-    a 'dalmatian'(pet label) and it will match to the classifier label 
-    'dalmatian, coach dog, carriage dog' if the classifier function correctly 
+    a 'dalmatian'(pet label) and it will match to the classifier label
+    'dalmatian, coach dog, carriage dog' if the classifier function correctly
     classified the pet images of dalmatians.
-     PLEASE NOTE: This function uses the classifier() function defined in 
+     PLEASE NOTE: This function uses the classifier() function defined in
      classifier.py within this function. The proper use of this function is
-     in test_classifier.py Please refer to this program prior to using the 
-     classifier() function to classify images within this function 
-     Parameters: 
+     in test_classifier.py Please refer to this program prior to using the
+     classifier() function to classify images within this function
+     Parameters:
       images_dir - The (full) path to the folder of images that are to be
                    classified by the classifier function (string)
       results_dic - Results Dictionary with 'key' as image filename and 'value'
-                    as a List. Where the list will contain the following items: 
+                    as a List. Where the list will contain the following items:
                   index 0 = pet image label (string)
                 --- where index 1 & index 2 are added by this function ---
                   NEW - index 1 = classifier label (string)
                   NEW - index 2 = 1/0 (int)  where 1 = match between pet image
                     and classifer labels and 0 = no match between labels
-      model - Indicates which CNN model architecture will be used by the 
+      model - Indicates which CNN model architecture will be used by the
               classifier function to classify the pet images,
               values must be either: resnet alexnet vgg (string)
      Returns:
-           None - results_dic is mutable data type so no return needed.         
+           None - results_dic is mutable data type so no return needed.
     """
     # Process al files in the results_dic - use images_dir to give fullpath
     # that indicates the folder and the filename (key) to be used in the
     # classifier function
     for key, value in results_dic.items():
-        
+
         # Runs classifier function to classify the images classifier function
         # inputs: path + filename and model, returns model_label
         # as classifier label
         model_label = classifier(os.path.join(images_dir, key), model)
-        
+
         # Processes the results so they can be compared with pet image labels
         # Set labels to lowercase (lower) and stripping off whitespace(strip)
         model_label = model_label.lower().strip()
-        
+
         # Defines truth as pet image label
         truth = value[0]
-        
+
         # If the pet image label is found within the classifier label list of terms
         # as an exact match to one of the terms in the list - then they are added to
         # results_dic as an exact match(1) using extend list function
         if truth in model_label:
             value.extend((model_label, 1))
-            
+
         # If not found then added to results dictionary as NOT a match(0) using
         # the extend function
         else:

--- a/get_input_args.py
+++ b/get_input_args.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # */AIPND-revision/intropyproject-classify-pet-images/get_input_args.py
-#                                                                             
+#
 # PROGRAMMER: Nick Ferguson
-# DATE CREATED: 2/6/23                                  
+# DATE CREATED: 2/6/23
 # REVISED DATE: 2/26/23
-# PURPOSE: Create a function that retrieves the following 3 command line inputs 
-#          from the user using the Argparse Python module. If the user fails to 
+# PURPOSE: Create a function that retrieves the following 3 command line inputs
+#          from the user using the Argparse Python module. If the user fails to
 #          provide some or all of the 3 inputs, then the default values are
 #          used for the missing inputs. Command Line Arguments:
 #     1. Image Folder as --dir with default value 'pet_images'
@@ -17,17 +17,17 @@
 # Imports python modules
 import argparse
 
-# TODO 1: Define get_input_args function below please be certain to replace None
-#       in the return statement with parser.parse_args() parsed argument 
+
+#       in the return statement with parser.parse_args() parsed argument
 #       collection that you created with this function
-# 
+#
 def get_input_args():
     """
     Retrieves and parses the 3 command line arguments provided by the user when
-    they run the program from a terminal window. This function uses Python's 
-    argparse module to created and defined these 3 command line arguments. If 
-    the user fails to provide some or all of the 3 arguments, then the default 
-    values are used for the missing arguments. 
+    they run the program from a terminal window. This function uses Python's
+    argparse module to created and defined these 3 command line arguments. If
+    the user fails to provide some or all of the 3 arguments, then the default
+    values are used for the missing arguments.
     Command Line Arguments:
       1. Image Folder as --dir with default value 'pet_images'
       2. CNN Model Architecture as --arch with default value 'vgg'
@@ -36,19 +36,25 @@ def get_input_args():
     Parameters:
      None - simply using argparse module to create & store command line arguments
     Returns:
-     parse_args() -data structure that stores the command line arguments object  
+     parse_args() -data structure that stores the command line arguments object
     """
     # Create Parse using ArgumentParser
     parser = argparse.ArgumentParser()
-    
+
     # Create 3 command line arguments as mentioned above using add_argument() from ArguementParser method
-    parser.add_argument('--dir', type=str, default='pet_images/',
-                        help='path to folder of images')
-    parser.add_argument('--arch', default = 'vgg', choices = ['vgg', 'alexnet', 'resnet'],
-                       help='chosen model')
-    parser.add_argument('--dogfile', default = 'dognames.txt',
-                       help='text file that has dognames')
-    
-    # Replace None with parser.parse_args() parsed argument collection that 
-    # you created with this function 
+    parser.add_argument(
+        "--dir", type=str, default="pet_images/", help="path to folder of images"
+    )
+    parser.add_argument(
+        "--arch",
+        default="vgg",
+        choices=["vgg", "alexnet", "resnet"],
+        help="chosen model",
+    )
+    parser.add_argument(
+        "--dogfile", default="dognames.txt", help="text file that has dognames"
+    )
+
+    # Replace None with parser.parse_args() parsed argument collection that
+    # you created with this function
     return parser.parse_args()

--- a/get_pet_labels.py
+++ b/get_pet_labels.py
@@ -1,16 +1,16 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # */AIPND-revision/intropyproject-classify-pet-images/get_pet_labels.py
-#                                                                             
+#
 # PROGRAMMER: Nick Ferguson
-# DATE CREATED: 2/6/23                      
+# DATE CREATED: 2/6/23
 # REVISED DATE: 2/26/23
-# PURPOSE: Create the function get_pet_labels that creates the pet labels from 
-#          the image's filename. This function inputs: 
-#           - The Image Folder as image_dir within get_pet_labels function and 
-#             as in_arg.dir for the function call within the main function. 
+# PURPOSE: Create the function get_pet_labels that creates the pet labels from
+#          the image's filename. This function inputs:
+#           - The Image Folder as image_dir within get_pet_labels function and
+#             as in_arg.dir for the function call within the main function.
 #          This function creates and returns the results dictionary as results_dic
-#          within get_pet_labels function and as results within main. 
+#          within get_pet_labels function and as results within main.
 #          The results_dic dictionary has a 'key' that's the image filename and
 #          a 'value' that's a list. This list will contain the following item
 #          at index 0 : pet image label (string).
@@ -19,15 +19,15 @@
 # Imports python modules
 from os import listdir
 
-# TODO 2: Define get_pet_labels function below please be certain to replace None
-#       in the return statement with results_dic dictionary that you create 
+
+#       in the return statement with results_dic dictionary that you create
 #       with this function
-# 
+#
 def get_pet_labels(image_dir):
     """
-    Creates a dictionary of pet labels (results_dic) based upon the filenames 
-    of the image files. These pet image labels are used to check the accuracy 
-    of the labels that are returned by the classifier function, since the 
+    Creates a dictionary of pet labels (results_dic) based upon the filenames
+    of the image files. These pet image labels are used to check the accuracy
+    of the labels that are returned by the classifier function, since the
     filenames of the images contain the true identity of the pet in the image.
     Be sure to format the pet labels so that they are in all lower case letters
     and with leading and trailing whitespace characters stripped from them.
@@ -36,32 +36,33 @@ def get_pet_labels(image_dir):
      image_dir - The (full) path to the folder of images that are to be
                  classified by the classifier function (string)
     Returns:
-      results_dic - Dictionary with 'key' as image filename and 'value' as a 
+      results_dic - Dictionary with 'key' as image filename and 'value' as a
       List. The list contains for following item:
          index 0 = pet image label (string)
     """
     # Create a list with image file names
     in_files = listdir(image_dir)
-    
+
     # Processes each of the files to create a dictionary where the key
     # is the filename and the value is the picture label (below).
-    
+
     # Create empty dictionary for the results (pet labels, etc.)
     results_dic = {}
-    
+
     # Processes through each file in the directory, extracting only the words
     # of the file that contain the pet image label
-    for filename in in_files[0:len(in_files):1]:
-        
+    for filename in in_files[0 : len(in_files) : 1]:
+
         # Skips file if starts with . (like .DS_Store of Mac OSX) because it
         # isn't an pet image file
         if filename[0] != ".":
-            
+
             # Uses split to extract words of filename into list image_name
             image_name = filename.split("_")
-            
-             
-            pet_label = " ".join([word.lower() for word in image_name if word.isalpha()])
+
+            pet_label = " ".join(
+                [word.lower() for word in image_name if word.isalpha()]
+            )
             """
             Takes a list of words (image_name) and returns a string that contains only 
             the words that are all alphabetic characters (i.e., only letters). The words are converted 
@@ -75,18 +76,17 @@ def get_pet_labels(image_dir):
             of all the words in the image filename that consist only of alphabetic characters (i.e., 
             no numbers or special characters). The words are joined with spaces and converted to lowercase.
             """
-                    
+
             # Strips off trailing whitespace
             pet_label = pet_label.strip()
-            
+
             # If filename doesn't already exist in dictionary add it and it's
             # pet label - otherwise print an error message because indicates
             # duplicate files (filename)
             if filename not in results_dic:
                 results_dic[filename] = [pet_label]
-                
+
             else:
-                print("** Warning: Duplicate files exist in directory:",
-                      filename)
-  
+                print("** Warning: Duplicate files exist in directory:", filename)
+
     return results_dic

--- a/print_functions_for_lab_checks.py
+++ b/print_functions_for_lab_checks.py
@@ -1,18 +1,19 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # */AIPND/intropylab-classifying-images/print_functions_for_lab_checks.py
-#                                                                             
-# PROGRAMMER: Jennifer S.                                                    
-# DATE CREATED: 05/14/2018                                  
-# REVISED DATE:             <=(Date Revised - if any)                         
-# PURPOSE:  This set of functions can be used to check your code after programming 
+#
+# PROGRAMMER: Jennifer S.
+# DATE CREATED: 05/14/2018
+# REVISED DATE:             <=(Date Revised - if any)
+# PURPOSE:  This set of functions can be used to check your code after programming
 #           each function. The top section of each part of the lab contains
 #           the section labeled 'Checking your code'. When directed within this
-#           section of the lab one can use these functions to more easily check 
+#           section of the lab one can use these functions to more easily check
 #           your code. See the docstrings below each function for details on how
 #           to use the function within your code.
 #
 ##
+
 
 # Functions below defined to help with "Checking your code", specifically
 # running these functions with the appropriate input arguments within the
@@ -21,93 +22,116 @@
 def check_command_line_arguments(in_arg):
     """
     For Lab: Classifying Images - 7. Command Line Arguments
-    Prints each of the command line arguments passed in as parameter in_arg, 
-    assumes you defined all three command line arguments as outlined in 
+    Prints each of the command line arguments passed in as parameter in_arg,
+    assumes you defined all three command line arguments as outlined in
     '7. Command Line Arguments'
     Parameters:
      in_arg -data structure that stores the command line arguments object
     Returns:
-     Nothing - just prints to console  
+     Nothing - just prints to console
     """
     if in_arg is None:
-        print("* Doesn't Check the Command Line Arguments because 'get_input_args' hasn't been defined.")
+        print(
+            "* Doesn't Check the Command Line Arguments because 'get_input_args' hasn't been defined."
+        )
     else:
         # prints command line agrs
-        print("Command Line Arguments:\n     dir =", in_arg.dir, 
-              "\n    arch =", in_arg.arch, "\n dogfile =", in_arg.dogfile)
+        print(
+            "Command Line Arguments:\n     dir =",
+            in_arg.dir,
+            "\n    arch =",
+            in_arg.arch,
+            "\n dogfile =",
+            in_arg.dogfile,
+        )
+
 
 def check_creating_pet_image_labels(results_dic):
-    """    For Lab: Classifying Images - 9/10. Creating Pet Image Labels
-    Prints first 10 key-value pairs and makes sure there are 40 key-value 
+    """For Lab: Classifying Images - 9/10. Creating Pet Image Labels
+    Prints first 10 key-value pairs and makes sure there are 40 key-value
     pairs in your results_dic dictionary. Assumes you defined the results_dic
-    dictionary as was outlined in 
+    dictionary as was outlined in
     '9/10. Creating Pet Image Labels'
     Parameters:
-      results_dic - Dictionary with key as image filename and value as a List 
+      results_dic - Dictionary with key as image filename and value as a List
              (index)idx 0 = pet image label (string)
     Returns:
-     Nothing - just prints to console  
+     Nothing - just prints to console
     """
     if results_dic is None:
-        print("* Doesn't Check the Results Dictionary because 'get_pet_labels' hasn't been defined.")
+        print(
+            "* Doesn't Check the Results Dictionary because 'get_pet_labels' hasn't been defined."
+        )
     else:
         # Code to print 10 key-value pairs (or fewer if less than 10 images)
         # & makes sure there are 40 pairs, one for each file in pet_images/
         stop_point = len(results_dic)
         if stop_point > 10:
             stop_point = 10
-        print("\nPet Image Label Dictionary has", len(results_dic),
-              "key-value pairs.\nBelow are", stop_point, "of them:")
-    
+        print(
+            "\nPet Image Label Dictionary has",
+            len(results_dic),
+            "key-value pairs.\nBelow are",
+            stop_point,
+            "of them:",
+        )
+
         # counter - to count how many labels have been printed
         n = 0
-    
+
         # for loop to iterate through the dictionary
         for key in results_dic:
- 
+
             # prints only first 10 labels
             if n < stop_point:
-                print("{:2d} key: {:>30}  label: {:>26}".format(n+1, key,
-                      results_dic[key][0]) )
+                print(
+                    "{:2d} key: {:>30}  label: {:>26}".format(
+                        n + 1, key, results_dic[key][0]
+                    )
+                )
 
                 # Increments counter
                 n += 1
-            
+
             # If past first 10 (or fewer) labels the breaks out of loop
             else:
                 break
 
 
 def check_classifying_images(results_dic):
-    """    For Lab: Classifying Images - 11/12. Classifying Images
-    Prints Pet Image Label and Classifier Label for ALL Matches followed by ALL 
-    NOT matches. Next prints out the total number of images followed by how 
+    """For Lab: Classifying Images - 11/12. Classifying Images
+    Prints Pet Image Label and Classifier Label for ALL Matches followed by ALL
+    NOT matches. Next prints out the total number of images followed by how
     many were matches and how many were not-matches to check all 40 images are
-    processed. Assumes you defined the results_dic dictionary as was 
+    processed. Assumes you defined the results_dic dictionary as was
     outlined in '11/12. Classifying Images'
     Parameters:
-      results_dic - Dictionary with key as image filename and value as a List 
+      results_dic - Dictionary with key as image filename and value as a List
              (index)idx 0 = pet image label (string)
                     idx 1 = classifier label (string)
-                    idx 2 = 1/0 (int)   where 1 = match between pet image and 
+                    idx 2 = 1/0 (int)   where 1 = match between pet image and
                     classifer labels and 0 = no match between labels
     Returns:
-     Nothing - just prints to console  
+     Nothing - just prints to console
 
     """
     if results_dic is None:
-        print("* Doesn't Check the Results Dictionary because 'classify_images' hasn't been defined.")
+        print(
+            "* Doesn't Check the Results Dictionary because 'classify_images' hasn't been defined."
+        )
     elif len(results_dic[next(iter(results_dic))]) < 2:
-        print("* Doesn't Check the Results Dictionary because 'classify_images' hasn't been defined.")
+        print(
+            "* Doesn't Check the Results Dictionary because 'classify_images' hasn't been defined."
+        )
     else:
         # Code for checking classify_images -
         # Checks matches and not matches are classified correctly
         # Checks that all 40 images are classified as a Match or Not-a Match
-    
+
         # Sets counters for matches & NOT-matches
         n_match = 0
         n_notmatch = 0
-    
+
         # Prints all Matches first
         print("\n     MATCH:")
         for key in results_dic:
@@ -117,64 +141,80 @@ def check_classifying_images(results_dic):
 
                 # Increments Match counter
                 n_match += 1
-                print("\n{:>30}: \nReal: {:>26}   Classifier: {:>30}".format(key, 
-                      results_dic[key][0], results_dic[key][1]))
+                print(
+                    "\n{:>30}: \nReal: {:>26}   Classifier: {:>30}".format(
+                        key, results_dic[key][0], results_dic[key][1]
+                    )
+                )
 
         # Prints all NOT-Matches next
         print("\n NOT A MATCH:")
         for key in results_dic:
-        
-            # Prints only if NOT-a-Match Index 2 == 0 
+
+            # Prints only if NOT-a-Match Index 2 == 0
             if results_dic[key][2] == 0:
- 
+
                 # Increments Not-a-Match counter
                 n_notmatch += 1
-                print("\n{:>30}: \nReal: {:>26}   Classifier: {:>30}".format(key,
-                      results_dic[key][0], results_dic[key][1]))
+                print(
+                    "\n{:>30}: \nReal: {:>26}   Classifier: {:>30}".format(
+                        key, results_dic[key][0], results_dic[key][1]
+                    )
+                )
 
         # Prints Total Number of Images - expects 40 from pet_images folder
-        print("\n# Total Images",n_match + n_notmatch, "# Matches:",n_match ,
-              "# NOT Matches:",n_notmatch)
+        print(
+            "\n# Total Images",
+            n_match + n_notmatch,
+            "# Matches:",
+            n_match,
+            "# NOT Matches:",
+            n_notmatch,
+        )
 
- 
+
 def check_classifying_labels_as_dogs(results_dic):
-    """    For Lab: Classifying Images - 13. Classifying Labels as Dogs
+    """For Lab: Classifying Images - 13. Classifying Labels as Dogs
     Prints Pet Image Label, Classifier Label, whether Pet Label is-a-dog(1=Yes,
-    0=No), and whether Classifier Label is-a-dog(1=Yes, 0=No) for ALL Matches 
-    followed by ALL NOT matches. Next prints out the total number of images 
-    followed by how many were matches and how many were not-matches to check 
+    0=No), and whether Classifier Label is-a-dog(1=Yes, 0=No) for ALL Matches
+    followed by ALL NOT matches. Next prints out the total number of images
+    followed by how many were matches and how many were not-matches to check
     all 40 images are processed. Assumes you defined the results_dic dictionary
     as was outlined in '13. Classifying Labels as Dogs'
     Parameters:
-      results_dic - Dictionary with key as image filename and value as a List 
+      results_dic - Dictionary with key as image filename and value as a List
              (index)idx 0 = pet image label (string)
                     idx 1 = classifier label (string)
-                    idx 2 = 1/0 (int)   where 1 = match between pet image and 
+                    idx 2 = 1/0 (int)   where 1 = match between pet image and
                     classifer labels and 0 = no match between labels
-                    idx 3 = 1/0 (int)  where 1 = pet image 'is-a' dog and 
-                            0 = pet Image 'is-NOT-a' dog. 
-                    idx 4 = 1/0 (int)  where 1 = Classifier classifies image 
-                            'as-a' dog and 0 = Classifier classifies image  
+                    idx 3 = 1/0 (int)  where 1 = pet image 'is-a' dog and
+                            0 = pet Image 'is-NOT-a' dog.
+                    idx 4 = 1/0 (int)  where 1 = Classifier classifies image
+                            'as-a' dog and 0 = Classifier classifies image
                             'as-NOT-a' dog.
     Returns:
-     Nothing - just prints to console  
+     Nothing - just prints to console
 
     """
     if results_dic is None:
-        print("* Doesn't Check the Results Dictionary because 'adjust_results4_isadog' hasn't been defined.")
-    elif len(results_dic[next(iter(results_dic))]) < 4 :
-        print("* Doesn't Check the Results Dictionary because 'adjust_results4_isadog' hasn't been defined.")
+        print(
+            "* Doesn't Check the Results Dictionary because 'adjust_results4_isadog' hasn't been defined."
+        )
+    elif len(results_dic[next(iter(results_dic))]) < 4:
+        print(
+            "* Doesn't Check the Results Dictionary because 'adjust_results4_isadog' hasn't been defined."
+        )
 
     else:
         # Code for checking adjust_results4_isadog -
         # Checks matches and not matches are classified correctly as "dogs" and
-        # "not-dogs" Checks that all 40 images are classified as a Match or Not-a 
+        # "not-dogs" Checks that all 40 images are classified as a Match or Not-a
         # Match
-    
+
         # Sets counters for matches & NOT-matches
         n_match = 0
         n_notmatch = 0
-    
+
         # Prints all Matches first
         print("\n     MATCH:")
         for key in results_dic:
@@ -184,70 +224,89 @@ def check_classifying_labels_as_dogs(results_dic):
 
                 # Increments Match counter
                 n_match += 1
-                print("\n{:>30}: \nReal: {:>26}   Classifier: {:>30}  \nPetLabelDog: {:1d}  ClassLabelDog: {:1d}".format(key,
-                      results_dic[key][0], results_dic[key][1], results_dic[key][3], 
-                      results_dic[key][4]))
+                print(
+                    "\n{:>30}: \nReal: {:>26}   Classifier: {:>30}  \nPetLabelDog: {:1d}  ClassLabelDog: {:1d}".format(
+                        key,
+                        results_dic[key][0],
+                        results_dic[key][1],
+                        results_dic[key][3],
+                        results_dic[key][4],
+                    )
+                )
 
         # Prints all NOT-Matches next
         print("\n NOT A MATCH:")
         for key in results_dic:
-        
-            # Prints only if NOT-a-Match Index 2 == 0 
+
+            # Prints only if NOT-a-Match Index 2 == 0
             if results_dic[key][2] == 0:
- 
+
                 # Increments Not-a-Match counter
                 n_notmatch += 1
-                print("\n{:>30}: \nReal: {:>26}   Classifier: {:>30}  \nPetLabelDog: {:1d}  ClassLabelDog: {:1d}".format(key,
-                      results_dic[key][0], results_dic[key][1], results_dic[key][3], 
-                      results_dic[key][4]))
+                print(
+                    "\n{:>30}: \nReal: {:>26}   Classifier: {:>30}  \nPetLabelDog: {:1d}  ClassLabelDog: {:1d}".format(
+                        key,
+                        results_dic[key][0],
+                        results_dic[key][1],
+                        results_dic[key][3],
+                        results_dic[key][4],
+                    )
+                )
 
         # Prints Total Number of Images - expects 40 from pet_images folder
-        print("\n# Total Images",n_match + n_notmatch, "# Matches:",n_match ,
-              "# NOT Matches:",n_notmatch)
-
+        print(
+            "\n# Total Images",
+            n_match + n_notmatch,
+            "# Matches:",
+            n_match,
+            "# NOT Matches:",
+            n_notmatch,
+        )
 
 
 def check_calculating_results(results_dic, results_stats_dic):
-    """    For Lab: Classifying Images - 14. Calculating Results
+    """For Lab: Classifying Images - 14. Calculating Results
     Prints First statistics from the results stats dictionary (that was created
     by the calculates_results_stats() function), then prints the same statistics
     that were calculated in this function using the results dictionary.
-    Assumes you defined the results_stats dictionary and the statistics 
+    Assumes you defined the results_stats dictionary and the statistics
     as was outlined in '14. Calculating Results '
     Parameters:
-      results_dic - Dictionary with key as image filename and value as a List 
+      results_dic - Dictionary with key as image filename and value as a List
              (index)idx 0 = pet image label (string)
                     idx 1 = classifier label (string)
-                    idx 2 = 1/0 (int)   where 1 = match between pet image and 
+                    idx 2 = 1/0 (int)   where 1 = match between pet image and
                     classifer labels and 0 = no match between labels
-                    idx 3 = 1/0 (int)  where 1 = pet image 'is-a' dog and 
-                            0 = pet Image 'is-NOT-a' dog. 
-                    idx 4 = 1/0 (int)  where 1 = Classifier classifies image 
-                            'as-a' dog and 0 = Classifier classifies image  
+                    idx 3 = 1/0 (int)  where 1 = pet image 'is-a' dog and
+                            0 = pet Image 'is-NOT-a' dog.
+                    idx 4 = 1/0 (int)  where 1 = Classifier classifies image
+                            'as-a' dog and 0 = Classifier classifies image
                             'as-NOT-a' dog.
      results_stats_dic - Dictionary that contains the results statistics (either
-                     a percentage or a count) where the key is the statistic's 
+                     a percentage or a count) where the key is the statistic's
                      name (starting with 'pct' for percentage or 'n' for count)
-                     and the value is the statistic's value 
+                     and the value is the statistic's value
     Returns:
-     Nothing - just prints to console  
+     Nothing - just prints to console
 
     """
     if results_stats_dic is None:
-        print("* Doesn't Check the Results Dictionary because 'calculates_results_stats' hasn't been defined.")
+        print(
+            "* Doesn't Check the Results Dictionary because 'calculates_results_stats' hasn't been defined."
+        )
     else:
         # Code for checking results_stats_dic -
         # Checks calculations of counts & percentages BY using results_dic
         # to re-calculate the values and then compare to the values
         # in results_stats_dic
-    
+
         # Initialize counters to zero and number of images total
         n_images = len(results_dic)
         n_pet_dog = 0
         n_class_cdog = 0
         n_class_cnotd = 0
         n_match_breed = 0
-    
+
         # Interates through results_dic dictionary to recompute the statistics
         # outside of the calculates_results_stats() function
         for key in results_dic:
@@ -273,9 +332,9 @@ def check_calculating_results(results_dic, results_stats_dic):
 
             # NOT - match (not a breed match if a dog)
             else:
- 
+
                 # NOT - match
-                # isa dog (pet label) 
+                # isa dog (pet label)
                 if results_dic[key][3] == 1:
                     n_pet_dog += 1
 
@@ -290,21 +349,32 @@ def check_calculating_results(results_dic, results_stats_dic):
                     if results_dic[key][4] == 0:
                         n_class_cnotd += 1
 
-                    
         # calculates statistics based upon counters from above
         n_pet_notd = n_images - n_pet_dog
-        pct_corr_dog = ( n_class_cdog / n_pet_dog )*100
-        pct_corr_notdog = ( n_class_cnotd / n_pet_notd )*100
-        pct_corr_breed = ( n_match_breed / n_pet_dog )*100
-    
+        pct_corr_dog = (n_class_cdog / n_pet_dog) * 100
+        pct_corr_notdog = (n_class_cnotd / n_pet_notd) * 100
+        pct_corr_breed = (n_match_breed / n_pet_dog) * 100
+
         # prints calculated statistics
         print("\n ** Statistics from calculates_results_stats() function:")
-        print("N Images: {:2d}  N Dog Images: {:2d}  N NotDog Images: {:2d} \nPct Corr dog: {:5.1f} Pct Corr NOTdog: {:5.1f}  Pct Corr Breed: {:5.1f}".format(
-              results_stats_dic['n_images'], results_stats_dic['n_dogs_img'],
-              results_stats_dic['n_notdogs_img'], results_stats_dic['pct_correct_dogs'],
-              results_stats_dic['pct_correct_notdogs'],
-              results_stats_dic['pct_correct_breed']))
+        print(
+            "N Images: {:2d}  N Dog Images: {:2d}  N NotDog Images: {:2d} \nPct Corr dog: {:5.1f} Pct Corr NOTdog: {:5.1f}  Pct Corr Breed: {:5.1f}".format(
+                results_stats_dic["n_images"],
+                results_stats_dic["n_dogs_img"],
+                results_stats_dic["n_notdogs_img"],
+                results_stats_dic["pct_correct_dogs"],
+                results_stats_dic["pct_correct_notdogs"],
+                results_stats_dic["pct_correct_breed"],
+            )
+        )
         print("\n ** Check Statistics - calculated from this function as a check:")
-        print("N Images: {:2d}  N Dog Images: {:2d}  N NotDog Images: {:2d} \nPct Corr dog: {:5.1f} Pct Corr NOTdog: {:5.1f}  Pct Corr Breed: {:5.1f}".format(
-              n_images, n_pet_dog, n_pet_notd, pct_corr_dog, pct_corr_notdog,
-              pct_corr_breed))
+        print(
+            "N Images: {:2d}  N Dog Images: {:2d}  N NotDog Images: {:2d} \nPct Corr dog: {:5.1f} Pct Corr NOTdog: {:5.1f}  Pct Corr Breed: {:5.1f}".format(
+                n_images,
+                n_pet_dog,
+                n_pet_notd,
+                pct_corr_dog,
+                pct_corr_notdog,
+                pct_corr_breed,
+            )
+        )

--- a/print_results.py
+++ b/print_results.py
@@ -1,119 +1,128 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # */AIPND-revision/intropyproject-classify-pet-images/print_results.py
-#                                                                             
+#
 # PROGRAMMER: Nick Ferguson
 # DATE CREATED: 2/9/23
 # REVISED DATE: 2/11/23
 # PURPOSE: Create a function print_results that prints the results statistics
-#          from the results statistics dictionary (results_stats_dic). It 
+#          from the results statistics dictionary (results_stats_dic). It
 #          should also allow the user to be able to print out cases of misclassified
-#          dogs and cases of misclassified breeds of dog using the Results 
-#          dictionary (results_dic).  
+#          dogs and cases of misclassified breeds of dog using the Results
+#          dictionary (results_dic).
 #         This function inputs:
-#            -The results dictionary as results_dic within print_results 
+#            -The results dictionary as results_dic within print_results
 #             function and results for the function call within main.
-#            -The results statistics dictionary as results_stats_dic within 
+#            -The results statistics dictionary as results_stats_dic within
 #             print_results function and results_stats for the function call within main.
 #            -The CNN model architecture as model wihtin print_results function
-#             and in_arg.arch for the function call within main. 
+#             and in_arg.arch for the function call within main.
 #            -Prints Incorrectly Classified Dogs as print_incorrect_dogs within
-#             print_results function and set as either boolean value True or 
+#             print_results function and set as either boolean value True or
 #             False in the function call within main (defaults to False)
 #            -Prints Incorrectly Classified Breeds as print_incorrect_breed within
-#             print_results function and set as either boolean value True or 
+#             print_results function and set as either boolean value True or
 #             False in the function call within main (defaults to False)
 #         This function does not output anything other than printing a summary
 #         of the final results.
 ##
-# TODO 6: Define print_results function below, specifically replace the None
-#       below by the function definition of the print_results function. 
-#       Notice that this function doesn't to return anything because it  
+#       Notice that this function doesn't to return anything because it
 #       prints a summary of the results using results_dic and results_stats_dic
-# 
-def print_results(results_dic, results_stats_dic, model, 
-                  print_incorrect_dogs = False, print_incorrect_breed = False):
+#
+def print_results(
+    results_dic,
+    results_stats_dic,
+    model,
+    print_incorrect_dogs=False,
+    print_incorrect_breed=False,
+):
     """
-    Prints summary results on the classification and then prints incorrectly 
-    classified dogs and incorrectly classified dog breeds if user indicates 
+    Prints summary results on the classification and then prints incorrectly
+    classified dogs and incorrectly classified dog breeds if user indicates
     they want those printouts (use non-default values)
     Parameters:
-      results_dic - Dictionary with key as image filename and value as a List 
+      results_dic - Dictionary with key as image filename and value as a List
              (index)idx 0 = pet image label (string)
                     idx 1 = classifier label (string)
-                    idx 2 = 1/0 (int)  where 1 = match between pet image and 
+                    idx 2 = 1/0 (int)  where 1 = match between pet image and
                             classifer labels and 0 = no match between labels
-                    idx 3 = 1/0 (int)  where 1 = pet image 'is-a' dog and 
-                            0 = pet Image 'is-NOT-a' dog. 
-                    idx 4 = 1/0 (int)  where 1 = Classifier classifies image 
-                            'as-a' dog and 0 = Classifier classifies image  
+                    idx 3 = 1/0 (int)  where 1 = pet image 'is-a' dog and
+                            0 = pet Image 'is-NOT-a' dog.
+                    idx 4 = 1/0 (int)  where 1 = Classifier classifies image
+                            'as-a' dog and 0 = Classifier classifies image
                             'as-NOT-a' dog.
       results_stats_dic - Dictionary that contains the results statistics (either
-                   a  percentage or a count) where the key is the statistic's 
+                   a  percentage or a count) where the key is the statistic's
                      name (starting with 'pct' for percentage or 'n' for count)
-                     and the value is the statistic's value 
-      model - Indicates which CNN model architecture will be used by the 
+                     and the value is the statistic's value
+      model - Indicates which CNN model architecture will be used by the
               classifier function to classify the pet images,
               values must be either: resnet alexnet vgg (string)
-      print_incorrect_dogs - True prints incorrectly classified dog images and 
-                             False doesn't print anything(default) (bool)  
-      print_incorrect_breed - True prints incorrectly classified dog breeds and 
-                              False doesn't print anything(default) (bool) 
+      print_incorrect_dogs - True prints incorrectly classified dog images and
+                             False doesn't print anything(default) (bool)
+      print_incorrect_breed - True prints incorrectly classified dog breeds and
+                              False doesn't print anything(default) (bool)
     Returns:
            None - simply printing results.
     """
-     # Prints the model architecture name
+    # Prints the model architecture name
     print("\n\n*** Results Summary for CNN Model Architecture", model.upper(), "***")
-   
+
     # Prints the number of images
-    print("{:20}: {:3d}".format('N Images', results_stats_dic['n_images']))
-    
+    print("{:20}: {:3d}".format("N Images", results_stats_dic["n_images"]))
+
     # Prints the number of dog images
-    print("{:20}: {:3d}".format('N Dog Images', results_stats_dic['n_dogs_img']))
-    
+    print("{:20}: {:3d}".format("N Dog Images", results_stats_dic["n_dogs_img"]))
+
     # Prints the number of not-a-dog images
-    print("{:20}: {:3d}".format('N Not-Dog Images', results_stats_dic['n_notdogs_img']))
-    
+    print("{:20}: {:3d}".format("N Not-Dog Images", results_stats_dic["n_notdogs_img"]))
+
     # Leaves a blank line
     print(" ")
-    
+
     # Prints summary statistics (pct) on Model Run
     for key in results_stats_dic:
-        if key[0] == 'p':
+        if key[0] == "p":
             print("{:20}: {:5.1f}".format(key, results_stats_dic[key]))
-            
+
     # If the print_incorrect_dogs == True AND there were images inccorrectly
     # classified as dogs or vice versa - print out these cases
-    if (print_incorrect_dogs and
-        ( (results_stats_dic['n_correct_dogs'] + results_stats_dic['n_correct_notdogs'])
-         != results_stats_dic['n_images'] )
-       ):
+    if print_incorrect_dogs and (
+        (results_stats_dic["n_correct_dogs"] + results_stats_dic["n_correct_notdogs"])
+        != results_stats_dic["n_images"]
+    ):
         # Prints the header for incorrect dog assignments
         print("\nINCORRECT Dog/NOT Dog Assignments:")
-        
+
         # Loops through the results_dic dictionary and prints the filenames of incorrectly classified dogs
         for key in results_dic:
-            
+
             if sum(results_dic[key][3:]) == 1:
-                   print("Real: {:>26}  Classifier: {:>30}".format(results_dic[key][0],
-                                                                   results_dic[key][1]))
-                #print("Real: {:>26}   Classifier: {:>30}".format(results_dic[key][0],results_dic[key][1]))
-                #print(results_dic[key][0], results_dic[key][1])
-                
+                print(
+                    "Real: {:>26}  Classifier: {:>30}".format(
+                        results_dic[key][0], results_dic[key][1]
+                    )
+                )
+            # print("Real: {:>26}   Classifier: {:>30}".format(results_dic[key][0],results_dic[key][1]))
+            # print(results_dic[key][0], results_dic[key][1])
+
     # If the print_incorrect_breed == True AND there were dogs whose breeds
-    # were incorrectly classified - print out these cases               
-    if (print_incorrect_breed and
-        (results_stats_dic['n_correct_dogs'] != results_stats_dic['n_correct_breed'])
-       ):
+    # were incorrectly classified - print out these cases
+    if print_incorrect_breed and (
+        results_stats_dic["n_correct_dogs"] != results_stats_dic["n_correct_breed"]
+    ):
         # Prints the header for incorrect breed assignments
         print("\nINCORRECT Dog Breed Assignment:")
-        
+
         # Loops through the results_dic dictionary and prints the real breed
         # and the classified breed of incorrectly classified breeds
         for key in results_dic:
-            
+
             # If the pet image label is-a-dog, classified as-a-dog, but the breed
             # is wrong
-            if (sum(results_dic[key][3:]) == 2 and results_dic[key][2] == 0):
-                print("Real: {:>26}   Classifier: {:>30}".format(results_dic[key][0],
-                                                                 results_dic[key][1]))
+            if sum(results_dic[key][3:]) == 2 and results_dic[key][2] == 0:
+                print(
+                    "Real: {:>26}   Classifier: {:>30}".format(
+                        results_dic[key][0], results_dic[key][1]
+                    )
+                )

--- a/test_classifier.py
+++ b/test_classifier.py
@@ -1,36 +1,42 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # */AIPND/intropylab-classifying-images/test_classifier.py
-#                                                                             
-# PROGRAMMER: Jennifer S.                                                    
-# DATE CREATED: 01/30/2018                                  
-# REVISED DATE:             <=(Date Revised - if any)                         
-# PURPOSE: To demonstrate the proper usage of the classifier() function that 
-#          is defined in classifier.py This function uses CNN model 
-#          architecture that has been pretrained on the ImageNet data to 
-#          classify images. The only model architectures that this function 
+#
+# PROGRAMMER: Jennifer S.
+# DATE CREATED: 01/30/2018
+# REVISED DATE:             <=(Date Revised - if any)
+# PURPOSE: To demonstrate the proper usage of the classifier() function that
+#          is defined in classifier.py This function uses CNN model
+#          architecture that has been pretrained on the ImageNet data to
+#          classify images. The only model architectures that this function
 #          will accept are: 'resnet', 'alexnet', and 'vgg'. See the example
 #          usage below.
 #
 # Usage: python test_classifier.py    -- will run program from commandline
 
-# Imports classifier function for using pretrained CNN to classify images 
-from classifier import classifier 
+# Imports classifier function for using pretrained CNN to classify images
+from classifier import classifier
 
 # Defines a dog test image from pet_images folder
-test_image="pet_images/Collie_03797.jpg"
+test_image = "pet_images/Collie_03797.jpg"
 
 # Defines a model architecture to be used for classification
-# NOTE: this function only works for model architectures: 
-#      'vgg', 'alexnet', 'resnet'  
+# NOTE: this function only works for model architectures:
+#      'vgg', 'alexnet', 'resnet'
 model = "vgg"
 
 # Demonstrates classifier() functions usage
 # NOTE: image_classication is a text string - It contains mixed case(both lower
-# and upper case letter) image labels that can be separated by commas when a 
+# and upper case letter) image labels that can be separated by commas when a
 # label has more than one word that can describe it.
 image_classification = classifier(test_image, model)
 
 # prints result from running classifier() function
-print("\nResults from test_classifier.py\nImage:", test_image, "using model:",
-      model, "was classified as a:", image_classification)
+print(
+    "\nResults from test_classifier.py\nImage:",
+    test_image,
+    "using model:",
+    model,
+    "was classified as a:",
+    image_classification,
+)


### PR DESCRIPTION
## Summary
- remove leftover TODO comments
- format repository with Black for PEP8 compliance
- add module header to `classifier.py`

## Testing
- `python -m py_compile *.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL')*
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68461e1ba8b88320a1307c8ca90d7e0e