### PR TITLE
Modernize classifier image handling

### DIFF
--- a/classifier.py
+++ b/classifier.py
@@ -6,9 +6,8 @@ Defines the classifier() function that returns a label for an image.
 import ast
 from PIL import Image
 import torchvision.transforms as transforms
-from torch.autograd import Variable
 import torchvision.models as models
-from torch import __version__
+import torch
 
 MODEL_LOADERS = {
     "resnet": lambda: models.resnet18(pretrained=True),
@@ -25,66 +24,38 @@ with open("imagenet1000_clsid_to_human.txt") as imagenet_classes_file:
 
 
 def classifier(img_path, model_name):
-    # load the image
-    img_pil = Image.open(img_path)
+    # load the image using a context manager
+    with Image.open(img_path) as img_pil:
+        # define transforms
+        preprocess = transforms.Compose(
+            [
+                transforms.Resize(256),
+                transforms.CenterCrop(224),
+                transforms.ToTensor(),
+                transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
+            ]
+        )
 
-    # define transforms
-    preprocess = transforms.Compose(
-        [
-            transforms.Resize(256),
-            transforms.CenterCrop(224),
-            transforms.ToTensor(),
-            transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
-        ]
-    )
+        # preprocess the image
+        img_tensor = preprocess(img_pil)
 
-    # preprocess the image
-    img_tensor = preprocess(img_pil)
+        # resize the tensor (add dimension for batch)
+        img_tensor.unsqueeze_(0)
+        # obtain model, instantiate if necessary
+        if model_name not in LOADED_MODELS:
+            loader = MODEL_LOADERS.get(model_name)
+            if loader is None:
+                raise ValueError(f"Unknown model: {model_name}")
+            LOADED_MODELS[model_name] = loader()
+        model = LOADED_MODELS[model_name]
 
-    # resize the tensor (add dimension for batch)
-    img_tensor.unsqueeze_(0)
+        # put model in evaluation mode
+        model = model.eval()
 
-    # wrap input in variable, wrap input in variable - no longer needed for
-    # v 0.4 & higher code changed 04/26/2018 by Jennifer S. to handle PyTorch upgrade
-    pytorch_ver = __version__.split(".")
-
-    # pytorch versions 0.4 & hihger - Variable depreciated so that it returns
-    # a tensor. So to address tensor as output (not wrapper) and to mimic the
-    # affect of setting volatile = True (because we are using pretrained models
-    # for inference) we can set requires_gradient to False. Here we just set
-    # requires_grad_ to False on our tensor
-    if int(pytorch_ver[0]) > 0 or int(pytorch_ver[1]) >= 4:
-        img_tensor.requires_grad_(False)
-
-    # pytorch versions less than 0.4 - uses Variable because not-depreciated
-    else:
-        # apply model to input
-        # wrap input in variable
-        data = Variable(img_tensor, volatile=True)
-
-    # obtain model, instantiate if necessary
-    if model_name not in LOADED_MODELS:
-        loader = MODEL_LOADERS.get(model_name)
-        if loader is None:
-            raise ValueError(f"Unknown model: {model_name}")
-        LOADED_MODELS[model_name] = loader()
-    model = LOADED_MODELS[model_name]
-
-    # puts model in evaluation mode
-    # instead of (default)training mode
-    model = model.eval()
-
-    # apply data to model - adjusted based upon version to account for
-    # operating on a Tensor for version 0.4 & higher.
-    if int(pytorch_ver[0]) > 0 or int(pytorch_ver[1]) >= 4:
-        output = model(img_tensor)
-
-    # pytorch versions less than 0.4
-    else:
-        # apply data to model
-        output = model(data)
-
-    # return index corresponding to predicted class
-    pred_idx = output.data.numpy().argmax()
+        # perform inference without tracking gradients
+        with torch.no_grad():
+            output = model(img_tensor)
+        # return index corresponding to predicted class
+        pred_idx = output.argmax().item()
 
     return imagenet_classes_dict[pred_idx]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -23,6 +23,8 @@ def test_classifier_stub(monkeypatch):
             return self
         def requires_grad_(self, flag):
             return self
+        def argmax(self):
+            return types.SimpleNamespace(item=lambda: 1)
 
     def dummy_preprocess(img):
         return DummyTensor()
@@ -47,13 +49,29 @@ def test_classifier_stub(monkeypatch):
         vgg16=lambda pretrained=True: DummyModel(),
     )
 
+    class DummyNoGrad:
+        def __enter__(self):
+            pass
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
     torch_stub = types.SimpleNamespace(
         __version__="1.0.0",
         autograd=types.SimpleNamespace(Variable=object),
+        no_grad=lambda: DummyNoGrad(),
     )
 
     torchvision_stub = types.SimpleNamespace(transforms=transforms_stub, models=models_stub)
-    image_stub = types.SimpleNamespace(open=lambda path: object())
+
+    class DummyImage:
+        def __enter__(self):
+            return object()
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+    image_stub = types.SimpleNamespace(open=lambda path: DummyImage())
 
     monkeypatch.setitem(sys.modules, 'PIL', types.SimpleNamespace(Image=image_stub))
     monkeypatch.setitem(sys.modules, 'PIL.Image', image_stub)


### PR DESCRIPTION
## Summary
- update `classifier` to use a context manager when opening images
- remove deprecated Variable logic and rely on `torch.no_grad`
- use `output.argmax().item()` for predictions
- adapt unit tests for new context manager and no_grad usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68520267619c832094f393a4c68d6c97